### PR TITLE
`java_windows.md` 文件的一些建议

### DIFF
--- a/zh-cn/tutorial/code.md
+++ b/zh-cn/tutorial/code.md
@@ -35,5 +35,5 @@
 
 > "C:\Users\Administrator\Desktop\Mcsmoke\Java\jre-8\bin\java.exe" -Dfile.encoding=UTF-8 -jar Paper-1.8.8.jar￼
 
-请注意. 对于1.14或更高版本的Java服务器 终端输入/输出编码应始终为您计算机的主要编码 即使您在启动参数中添加了指定 Java 程序编码`-Dfile.encoding=?`. `GB2312` `GBK`
+请注意. 对于1.14或更高版本的Java服务器 模拟终端(即非仿真终端)输入/输出编码应始终为您计算机的主要编码 即使您在启动参数中添加了指定 Java 程序编码`-Dfile.encoding=?`. `GB2312` `GBK`
 <br />

--- a/zh-cn/tutorial/java_windows.md
+++ b/zh-cn/tutorial/java_windows.md
@@ -47,8 +47,12 @@
 填写启动命令：
 
 ```
-java -Dfile.encoding=UTF-8 -jar "你的jar文件名，例如：paper-1.19-62.jar"
+java -Xmx6G -Xms6G -XX:+UseG1GC -Dfile.encoding=UTF-8 -jar "你的jar文件名，例如：paper-1.19-62.jar"
 ```
+
+> 如果需要 将`6G`修改成您想要分配的内存 `-Xmx?G -Xms?G` 6-16G是一个较为合适的范围.
+
+> 不要将一台计算机的所有可用内存分配给服务端! 请最多空出2G可用内存.
 
 创建！
 

--- a/zh-cn/tutorial/java_windows.md
+++ b/zh-cn/tutorial/java_windows.md
@@ -32,11 +32,11 @@
 
 - MCBBS 整合包: https://www.mcbbs.net/forum-serverpack-1.html
 
-如果您对访问阅读英语有困难，可以直接点击这个下载：
+如果您对访问阅读英语有困难，可以直接点击版本下载：
 
-- 1.18: https://api.papermc.io/v2/projects/paper/versions/1.18.2/builds/387/downloads/paper-1.18.2-387.jar
+- [1.18.2](https://api.papermc.io/v2/projects/paper/versions/1.18.2/builds/388/downloads/paper-1.18.2-388.jar)
 
-- 1.19: https://api.papermc.io/v2/projects/paper/versions/1.19/builds/62/downloads/paper-1.19-62.jar
+- [1.19.4](https://api.papermc.io/v2/projects/paper/versions/1.19.4/builds/516/downloads/paper-1.19.4-516.jar)
 
 <br />
 
@@ -47,7 +47,7 @@
 填写启动命令：
 
 ```
-java -Dfile.encoding=UTF-8 -jar "你的jar文件名，列如：paper-1.19-62.jar"
+java -Dfile.encoding=UTF-8 -jar "你的jar文件名，例如：paper-1.19-62.jar"
 ```
 
 创建！

--- a/zh-cn/tutorial/java_windows.md
+++ b/zh-cn/tutorial/java_windows.md
@@ -10,7 +10,26 @@
 
 ## 1. 安装 Java 环境
 
-`Minecraft 1.17` 以下版本需要 `java 8` 运行时环境，`1.17` 以上版本则直接升级到了 `Java 16` 运行时环境，两者版本跨度极大且并不完全兼容低版本，因而导致 `1.17` 以下版本的 `Minecraft` 服务端软件是无法运行在 `Java 16` 运行时环境的，所以您在架设您自己的服务端之前，需要先检查是否拥有对应的运行环境。
+在开始运行Java服务端之前 Java运行库是必不可少的.
+以下是一些Minecraft版本所需的对应的Java版本运行库列表:
+
+  - 1.7.x / 1.8.x / 1.9.x - 使用`Java7(不推荐)`或`Java8`
+  - 1.10.x / 1.12.x - 使用`Java8`运行
+  - 1.13.x / 1.15.x - 使用`Java8`或`Java9`, `Java11`运行
+  - 1.16.x / 1.17.x - 使用Java16运行
+  - 1.17.x / 1.18.x - 使用Java17或Java18运行
+  - 1.18.x / 1.19.x - 使用Java17或更高版本运行.
+  
+您可以在此处下载Java: `下列Java下载链接只适用于Windows 64位操作系统 如果您需要其它版本下载 请自行搜索`
+  - [Java JDK8 8u202](https://repo.huaweicloud.com/java/jdk/8u202-b08/jdk-8u202-windows-x64.exe) `安装程序`
+  - [Java JDK11 11.0.2](https://mirrors.huaweicloud.com/java/jdk/11.0.2+9/jdk-11.0.2_windows-x64_bin.exe) `安装程序`
+  - [Java JDK17 17.0.7](https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.exe) `安装程序`
+  
+> 请注意 这些列表仅供参考 您需要查看您的插件是否支持Java 以避免出现本可避免的不必要的麻烦  
+
+> 请找到适合您的计算机处理器架构以及操作系统合适的Java. **不要盲目地点击下载链接**  
+
+> Java16以及更高版本仅可以在64位系统上运行.  
 
 
 不同版本的 Minecraft 要求的 Java 版本不一致，这里您需要提前了解，可以前往 [这里](https://www.oracle.com/java/technologies/downloads/#jdk18-windows) 下载安装。

--- a/zh-cn/tutorial/java_windows.md
+++ b/zh-cn/tutorial/java_windows.md
@@ -22,7 +22,9 @@
   
 您可以在此处下载Java: `下列Java下载链接只适用于Windows 64位操作系统 如果您需要其它版本下载 请自行搜索`
   - [(Oracle)Java JDK8 8u202](https://repo.huaweicloud.com/java/jdk/8u202-b08/jdk-8u202-windows-x64.exe) `安装程序`
-  - [(Oracle)Java JDK11 11.0.2](https://mirrors.huaweicloud.com/java/jdk/11.0.2+9/jdk-11.0.2_windows-x64_bin.exe) `安装程序`
+  - [(Azul)Java JDK8 8.0.362](https://cdn.azul.com/zulu/bin/zulu8.68.0.21-ca-jdk8.0.362-win_x64.zip) `压缩归档`
+  - [(Azul)Java JDK11 11.0.18](https://cdn.azul.com/zulu/bin/zulu11.62.17-ca-jdk11.0.18-win_x64.msi) `安装程序`
+  - [(Azul)Java JDK11 11.0.19](https://cdn.azul.com/zulu/bin/zulu11.64.19-ca-jdk11.0.19-win_x64.zip) `压缩归档`
   - [(Oracle)Java JDK17 17.0.7](https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.exe) `安装程序`
   - [(Oracle)Java JDK17 17.0.7](https://download.oracle.com/java/17/archive/jdk-17.0.7_windows-x64_bin.zip) `压缩归档`
   

--- a/zh-cn/tutorial/java_windows.md
+++ b/zh-cn/tutorial/java_windows.md
@@ -13,12 +13,17 @@
 在开始运行Java服务端之前 Java运行库是必不可少的.
 以下是一些Minecraft版本所需的对应的Java版本运行库列表:
 
-  - 1.7.x / 1.8.x / 1.9.x - 使用`Java7(不推荐)`或`Java8`
+  - 1.7.x / 1.8.x / 1.9.x - 使用`Java7(不推荐)`或`Java8`运行
   - 1.10.x / 1.12.x - 使用`Java8`运行
-  - 1.13.x / 1.15.x - 使用`Java8`或`Java9`, `Java11`运行
-  - 1.16.x / 1.17.x - 使用Java16运行
-  - 1.17.x / 1.18.x - 使用Java17或Java18运行
-  - 1.18.x / 1.19.x - 使用Java17或更高版本运行.
+  - 1.12.x / 1.13.x / 1.15.x - 使用`Java8`,`Java9`或`Java12`运行
+  - 1.16.x - 使用`Java8`,`Java9`,`Java12`或`Java16`运行
+  - 1.17.x - 使用`Java16`或`Java17`运行
+  - 1.18.x - 使用Java17或Java18运行
+  - 1.18.x / 1.19.x - 使用Java17或**更高版本**运行.
+
+> `更高版本` 注意事项: Java20太新了 有很多东西可能不支持 推荐停留在Java19
+
+> 您始终应该查看自己的插件支持哪些Java版本再做出抉择 如果插件没有声明 最好询问插件开发者 以免引起不必要的麻烦.
   
 您可以在此处下载Java: `下列Java下载链接只适用于Windows 64位操作系统 如果您需要其它版本下载 请自行搜索`
   - [(Oracle)Java JDK8 8u202](https://repo.huaweicloud.com/java/jdk/8u202-b08/jdk-8u202-windows-x64.exe) `安装程序`
@@ -27,8 +32,6 @@
   - [(Azul)Java JDK11 11.0.19](https://cdn.azul.com/zulu/bin/zulu11.64.19-ca-jdk11.0.19-win_x64.zip) `压缩归档`
   - [(Oracle)Java JDK17 17.0.7](https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.exe) `安装程序`
   - [(Oracle)Java JDK17 17.0.7](https://download.oracle.com/java/17/archive/jdk-17.0.7_windows-x64_bin.zip) `压缩归档`
-  
-> 请注意 这些列表仅供参考 您需要查看您的插件是否支持Java 以避免出现本可避免的不必要的麻烦  
 
 > 请找到适合您的计算机处理器架构以及操作系统合适的Java. **不要盲目地点击下载链接**  
 
@@ -57,7 +60,7 @@
 
 - [1.18.2](https://api.papermc.io/v2/projects/paper/versions/1.18.2/builds/388/downloads/paper-1.18.2-388.jar)
 
-- [1.19.4](https://api.papermc.io/v2/projects/paper/versions/1.19.4/builds/516/downloads/paper-1.19.4-516.jar)
+- [1.19.4](https://api.papermc.io/v2/projects/paper/versions/1.19.4/builds/524/downloads/paper-1.19.4-524.jar)
 
 <br />
 

--- a/zh-cn/tutorial/java_windows.md
+++ b/zh-cn/tutorial/java_windows.md
@@ -21,9 +21,10 @@
   - 1.18.x / 1.19.x - 使用Java17或更高版本运行.
   
 您可以在此处下载Java: `下列Java下载链接只适用于Windows 64位操作系统 如果您需要其它版本下载 请自行搜索`
-  - [Java JDK8 8u202](https://repo.huaweicloud.com/java/jdk/8u202-b08/jdk-8u202-windows-x64.exe) `安装程序`
-  - [Java JDK11 11.0.2](https://mirrors.huaweicloud.com/java/jdk/11.0.2+9/jdk-11.0.2_windows-x64_bin.exe) `安装程序`
-  - [Java JDK17 17.0.7](https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.exe) `安装程序`
+  - [(Oracle)Java JDK8 8u202](https://repo.huaweicloud.com/java/jdk/8u202-b08/jdk-8u202-windows-x64.exe) `安装程序`
+  - [(Oracle)Java JDK11 11.0.2](https://mirrors.huaweicloud.com/java/jdk/11.0.2+9/jdk-11.0.2_windows-x64_bin.exe) `安装程序`
+  - [(Oracle)Java JDK17 17.0.7](https://download.oracle.com/java/17/latest/jdk-17_windows-x64_bin.exe) `安装程序`
+  - [(Oracle)Java JDK17 17.0.7](https://download.oracle.com/java/17/archive/jdk-17.0.7_windows-x64_bin.zip) `压缩归档`
   
 > 请注意 这些列表仅供参考 您需要查看您的插件是否支持Java 以避免出现本可避免的不必要的麻烦  
 
@@ -31,12 +32,11 @@
 
 > Java16以及更高版本仅可以在64位系统上运行.  
 
+**如何使用压缩归档?**
+如果您不想在您的电脑上安装Java 或者目前您不想更换主要的Java 那么使用一个压缩归档是一个比较好的选择.
+您只需要将文件解压(文件夹最好不要带空格) 然后在启动参数内将开头的`java`替换成您的压缩归档运行库路径即可. 
+`java路径/bin/java.exe`. 例如 `C:/Java/jdk-17.0.7/bin/java.exe ... -jar "你的jar文件名，例如：paper-1.19.4-516.jar"`
 
-不同版本的 Minecraft 要求的 Java 版本不一致，这里您需要提前了解，可以前往 [这里](https://www.oracle.com/java/technologies/downloads/#jdk18-windows) 下载安装。
-
-
-
-> 更高版本请点击上文的“这里”文字前往官方网站下载。
 
 <br />
 
@@ -66,7 +66,7 @@
 填写启动命令：
 
 ```
-java -Xmx6G -Xms6G -XX:+UseG1GC -Dfile.encoding=UTF-8 -jar "你的jar文件名，例如：paper-1.19-62.jar"
+java -Xmx6G -Xms6G -XX:+UseG1GC -Dfile.encoding=UTF-8 -jar "你的jar文件名，例如：paper-1.19.4-516.jar"
 ```
 
 > 如果需要 将`6G`修改成您想要分配的内存 `-Xmx?G -Xms?G` 6-16G是一个较为合适的范围.


### PR DESCRIPTION
> 此PR的第一个commit将 `列如` 修改成了 `例如` 并且更新了下载链接

> 当某项建议被采纳时 即应为标记为确认实现 我会自己完善文档内容.

此文档有些可以改进的地方 但我不确定我真的是否需要加入这些

  ~~我们是否应该列出全部版本的下载链接? (*1)~~
  - [x] 我认为应该列出每个版本支持的Java版本 而不是直接说 `1.17+就应该使用J17 低版本就使用J8` 这样的潦草话 (*2)
  ~~我们是否应该使用[此jvm](https://github.com/etil2jz/etil-minecraft-flags)参数作为例子? (*3)~~
  ~~我们是否在文档内列入其它服务端分叉并给他们一个选择 (*4)~~
  - [x] ~~我似乎忘记了这是一个MCSM文档 因为我只想做好~~

*1: 使用者应该清楚他们为什么要用这个版本 最新版通常包含有最新的错误修补 较旧的版本很容易受到攻击 `漏洞利用 etc` `即使可以通过找别人已经修补的分叉来完成这一点 虽然我无法提供太多建议 但这作为安全提醒 我想是应该的`
*2.1: 较新的Java版本能够适当提高垃圾回收器性能 (夹入好的jvm参数更佳) `当然我不是说ZGC什么的 G1GC到现在还在被大范围使用是有原因的`
*2.2: 那些过时的服务端无法在新的Java上的工作原因是它们的依赖不适用于新的Java 例如1.8的过时Netty 以及反射管道. `NoSuchFieldError` 某些大部分人仍在使用的1.8,1.12版本也有一批社区的人在维护 `e.x PandaSpigot(1.8.8), Akarin(1.12.2)` PandaSpigot就提供了在j20上运行1.8的能力. 并且加入了现代(1.10+)tick计时器
*3: 某些东西可能不适用于旧的Java版本 如果需要 我可以单独出适用于老版本的Java版本的启动参数.
*4.1: 我想我们不应该只列出Paper 很显然 对于某些人 Spigot或者Vanilla, Fabric服务端更适合他们
*4.2: 使用这些分叉造成的后果是自负的 他们应该将在使用那些分叉时遇到的问题报告给他们的开发人员 而不是怪罪MCSM. ~~俗称套盾~~

作为一篇面向新手的教程 即使可能看的不是新手 但我认为有必要描述清楚**很多东西** 避免**产生误导**. ~~要不然还是别写了(~~

> 或者如果考虑的话 我可以考虑在其它地方单独攒写这么一篇文章 并且可以进行中英各一个版本 ~~英语学上头了 中文都要讲不清了~~ ~~最怕的事情是写了那么多东西却没多少人看~~

> 如何传递焦虑.jpg 2333