### PR TITLE
Add instructions for using OpenRC to manage MCSManager as a Linux system service

### DIFF
--- a/getting-started/linux-service.md
+++ b/getting-started/linux-service.md
@@ -1,10 +1,12 @@
 # Register MCSM as a system service
 
-## Config
+## systemd Config
 
-**vim /etc/systemd/system/mcsm-daemon.service**
-
+```sh
+vim /etc/systemd/system/mcsm-daemon.service
 ```
+
+```systemd
 [Unit]
 Description=MCSManager Daemon
 
@@ -19,9 +21,11 @@ Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 WantedBy=multi-user.target
 ```
 
-**vim /etc/systemd/system/mcsm-web.service**
-
+```sh
+vim /etc/systemd/system/mcsm-web.service
 ```
+
+```systemd
 [Unit]
 Description=MCSManager Web
 
@@ -36,10 +40,11 @@ Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 WantedBy=multi-user.target
 ```
 
-<br />
+&nbsp;
 
-## Usage
-```
+## systemd Usage
+
+```sh
 #Restart web or daemon service
 systemctl restart mcsm-{daemon,web}.service
 
@@ -54,4 +59,97 @@ systemctl enable mcsm-{daemon,web}.service
 
 #Stop web or daemon service from run on system startup.
 systemctl disable mcsm-{daemon,web}.service
+```
+
+&nbsp;
+
+## OpenRC Config
+
+```sh
+vim /etc/init.d/mcsm-daemon
+
+```
+
+```sh
+#!/sbin/openrc-run
+
+name="MCSManager Daemon"
+command="${node_install_path}/bin/node /opt/mcsmanager/daemon/app.js"
+command_background="yes"
+directory="/opt/mcsmanager/daemon"
+pidfile="/var/run/mcsm-daemon.pid"
+output_log="/var/log/mcsm/daemon.log"
+error_log="/var/log/mcsm/daemon.err"
+supervisor="supervise-daemon"
+
+depend() {
+  need net localmount
+  use logger
+  after firewall
+}
+```
+
+```sh
+vim /etc/init.d/mcsm-web
+```
+
+```sh
+#!/sbin/openrc-run
+
+name="MCSManager Web"
+command="${node_install_path}/bin/node /opt/mcsmanager/web/app.js"
+command_background="yes"
+directory="/opt/mcsmanager/web"
+pidfile="/var/run/mcsm-web.pid"
+output_log="/var/log/mcsm/web.log"
+error_log="/var/log/mcsm/web.err"
+supervisor="supervise-daemon"
+
+depend() {
+  need net localmount
+  use logger
+  after firewall
+}
+```
+
+&nbsp;
+
+## OpenRC Usage
+
+Setup:
+
+```sh
+# make OpenRC scripts executable so they can be run
+chmod +x /etc/init.d/mcsm-daemon
+chmod +x /etc/init.d/mcsm-web
+
+# add mcsm-daemon and mcsm-web to default runlevel
+# to enable them to run on startup
+rc-update add mcsm-daemon default
+rc-update add mcsm-web default
+
+# start mcsm-daemon and mcsm-web services
+rc-service mcsm-daemon start
+rc-service mcsm-web start
+```
+
+Management:
+
+```sh
+# restart mcsm-daemon or mcsm-web services
+rc-service mcsm-daemon restart
+rc-service mcsm-web restart
+
+# start mcsm-daemon or mcsm-web services
+rc-service mcsm-daemon start
+rc-service mcsm-web start
+
+# stop mcsm-daemon or mcsm-web services
+rc-service mcsm-daemon stop
+rc-service mcsm-web stop
+
+# remove mcsm-daemon or mcsm-web from default runlevel
+# to disable them from running on startup
+rc-update delete mcsm-daemon default
+rc-update delete mcsm-web default
 ```


### PR DESCRIPTION
This pull request adds the instructions for using OpenRC to manage the MCSManager daemon and web backend that I mentiond in https://github.com/MCSManager/MCSManager/issues/918. The OpenRC instruction section has been added to `getting-started/linux-service.md` as both systemd and OpenRC serve similar purposes and this would also likely be more convenient for the reader.

My text editor recommended a couple changes. In the fenced code blocks, the language is specified so that any relevant syntax highlighting shows up properly. For horizontal spacing, the `<br />` tag was changed to `&nbsp;` as my text editor recommended against using inline HTML within the markdown file.