### PR TITLE
Add manual Linux installation, Link to correct Windows ZIP

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ By default, the installation script will take care of the dependencies. If you a
 
 ---
 
-#### Installation script (Recommand)
+#### Installation script (Recommended)
 
 Only supports `x86_64` architecture **Ubuntu**/**Centos**/**Debian**/**Archlinux**.
 
@@ -28,9 +28,51 @@ sudo su -c "wget -qO- https://mcsmanager.com/install-v10.sh | bash"
 
 If the above script failed to complete correctly, feel free to [submit an Issue](https://github.com/MCSManager/MCSManager/issues) and/or try Linux manual installation.
 
+#### Manual
+
+If the installation script failed to execute correctly, you can try install it manually.
+
+```bash
+# Create /opt directory if not already
+mkdir /opt
+# Switch to /opt
+cd /opt/
+# Download Node.js 20.11. If you already have Node.js 16+ installed, ignore this step.
+wget https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz
+# Decompress Node.js source
+tar -xvf node-v20.11.0-linux-x64.tar.xz
+# Add Node.js to system PATH
+ln -s /opt/node-v20.11.0-linux-x64/bin/node /usr/bin/node
+ln -s /opt/node-v20.11.0-linux-x64/bin/npm /usr/bin/npm
+
+# Prepare MCSM's installation directory
+mkdir /opt/mcsmanager/
+cd /opt/mcsmanager/
+
+# Download MCSManager
+wget https://github.com/MCSManager/MCSManager/releases/latest/download/mcsmanager_linux_release.tar.gz
+tar -zxf mcsmanager_linux_release.tar.gz
+
+# Install dependencies
+./install.sh
+
+# Please open two terminals or screens.
+
+# Start the daemon first.
+./start-daemon.sh
+
+# Start the web interface at the second terminal or screen.
+./start-web.sh
+
+# For web access, go to http://localhost:23333/
+# In general, the web interface will automatically scan and add the local daemon.
+```
+
+This installation approach does not automatically set up MCSManager as a system service. Therefore, it is necessary to use `screen` for management.
+
 ### Windows
 
-Start by downloading this [zip archive](https://mcsmanager.com/) and decompress to a local directory.
+Start by downloading this [zip archive](https://github.com/MCSManager/MCSManager/releases/latest/download/mcsmanager_windows_release.zip) and decompress to a local directory.
 
 ## Starting MCSManager
 


### PR DESCRIPTION
Just copied this from the README because I thought it's worth mentioning
Not sure about the Node.js step because in the installation script it installs version 16.20.2 (which is outdated and should be replaced by latest LTS imo)

If you actually require a certain Node version I think it would be best to use something like [`fnm`](https://github.com/Schniz/fnm)