### PR TITLE
添加last update 时间显示

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -4,8 +4,9 @@ import type { Config as ThemeConfig } from "@vue/theme";
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "MCSManager",
-
   description: "MCSManager Document",
+  lastUpdate: true,
+
   locales: {
     root: {
       label: "English",

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -5,7 +5,7 @@ import type { Config as ThemeConfig } from "@vue/theme";
 export default defineConfig({
   title: "MCSManager",
   description: "MCSManager Document",
-  lastUpdate: true,
+  lastUpdated: true,
 
   locales: {
     root: {


### PR DESCRIPTION
在文档页面的底部添加一个最后编辑日期，以便于用户知道单个页面的最后更新时间。