### PR TITLE
freebsd服务部分的mcsmd服务错误指正修改

### DIFF
--- a/zh_cn/advanced/freebsd_rc.md
+++ b/zh_cn/advanced/freebsd_rc.md
@@ -36,13 +36,13 @@ start_cmd="${name}_start"
 stop_cmd="${name}_stop"
 reload_cmd="${name}_reload"
 
-mcsmw_start()
+mcsmd_start()
 {
     cd ${workdir}
     /usr/sbin/daemon -p ${pidfile} -u ${user} /usr/local/bin/node app.js > /dev/null
 }
 
-mcsmw_stop()
+mcsmd_stop()
 {
     if [ -f $pidfile ]; then
         kill -QUIT $(cat $pidfile)
@@ -50,7 +50,7 @@ mcsmw_stop()
     fi
 }
 
-mcsmw_reload()
+mcsmd_reload()
 {
     if [ -f $pidfile ]; then
         kill -HUP $(cat $pidfile)


### PR DESCRIPTION
改了三个字母使得daemon部分服务能正常配置
![b5efd27a0cccee4248b6affd9957db14](https://github.com/user-attachments/assets/3d101462-e926-42bf-8c88-d3e3c4ba93c9)
name明明是mcsmd，但底下却写mcsmw_start，导致服务启动时出现以下错误
![4dc6611ee999d2167467b8cb2cfcfab7](https://github.com/user-attachments/assets/5ff1832a-b95e-40cc-a2d7-3b748ae7f4da)
如果修改掉这一部分（如下图）
![7b74b1c33b6364747c57e9b797c66eed](https://github.com/user-attachments/assets/68aa4f4a-af97-494a-91c8-13cbb3c1e818)
那么节点是可以正常启动连接的（如下图）
![9651a8afa9ad421d8fe0884f12e6369f](https://github.com/user-attachments/assets/ef2a3ee8-3023-476e-a330-d62711353a8a)
