### PR TITLE
fix: 替换英文文档中的国内链接

### DIFF
--- a/advanced/update_panel.md
+++ b/advanced/update_panel.md
@@ -24,7 +24,7 @@ If you originally installed MCSManager using the **one-click script**, you can s
 After executing the script, there's nothing else you need to do, and your MCSManager should automatically be updated to the latest version.
 
 ```bash
-sudo su -c "wget -qO- https://script.mcsmanager.com/setup_cn.sh | bash"
+sudo su -c "wget -qO- https://script.mcsmanager.com/setup.sh | bash"
 ```
 
 ### Manual Update for Linux Version

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ But if you install it manually, you need to meet the `Node 16+` runtime environm
 Because it needs to be registered to the system service, **The installation script must be run with root.**
 
 ```bash
-sudo su -c "wget -qO- https://script.mcsmanager.com/setup_cn.sh | bash"
+sudo su -c "wget -qO- https://script.mcsmanager.com/setup.sh | bash"
 ```
 
 ### Startup Method
@@ -98,7 +98,7 @@ Just enter two terminals and execute `Ctrl+C`.
 
 ## Windows Installation
 
-Just [download the ZIP file](http://oss.duzuii.com/MCSManager/MCSManager-ZH) and decompress it to run without any installation dependencies and without polluting the registry.
+Just [download the ZIP file](https://github.com/MCSManager/MCSManager/releases/latest/download/mcsmanager_windows_release.zip) and decompress it to run without any installation dependencies and without polluting the registry.
 
 ### Startup Method
 

--- a/install.md
+++ b/install.md
@@ -3,7 +3,7 @@
 ## Linux
 
 ```bash
-wget -qO- https://gitee.com/mcsmanager/script/raw/master/setup_cn.sh | bash
+wget -qO- https://gitee.com/mcsmanager/script/raw/master/setup.sh | bash
 ```
 
 If the Linux next-key script installation fails, you can [go here](https://github.com/MCSManager/MCSManager#linux) to install it manually.
@@ -12,7 +12,7 @@ If the Linux next-key script installation fails, you can [go here](https://githu
 
 ## Windows
 
-[Download Zip](https://cloud.alongw.cn/f/akrCY/mcsmanager_windows_release.zip)
+[Download Zip](https://github.com/MCSManager/MCSManager/releases/latest/download/mcsmanager_windows_release.zip)
 
 Just download and run, without any installation dependencies and without polluting the registry.
 

--- a/ops/config_files.md
+++ b/ops/config_files.md
@@ -16,7 +16,7 @@
   "loginInfo": "foo", // Login UI hint
   "canFileManager": true, // Allow all users to use file management
   "language": "zh_cn", // UI language
-  "quickInstallAddr": "https://mcsmanager.oss-cn-guangzhou.aliyuncs.com/quick_install.json", // Quick install json file path/address
+  "quickInstallAddr": "https://raw.githubusercontent.com/MCSManager/Script/refs/heads/master/templates.json", // Quick install json file path/address
 
   "redisUrl": "", // Redis database, NOT RECOMMAND
   "dataPort": 23334, // Deprecated

--- a/setup_bedrock_edition.md
+++ b/setup_bedrock_edition.md
@@ -10,7 +10,7 @@ For Windows, we suggest using `Windows Server 2016`, `Windows 10`, or the latest
 
 ### Downloading Server Core
 
-You will find the latest official Bedrock Edition server core on [the official Minecraft Bedrock website](https://www.minecraft.net/zh-hans/download/server/bedrock).
+You will find the latest official Bedrock Edition server core on [the official Minecraft Bedrock website](https://www.minecraft.net/en-us/download/server/bedrock).
 
 ### Starting the Server
 
@@ -32,7 +32,7 @@ Install Microsoft VC++ from microsoft official website.
 
 ### Downloading Server Core
 
-You will find the latest official Bedrock Edition server core on [the official Minecraft Bedrock website](https://www.minecraft.net/zh-hans/download/server/bedrock).
+You will find the latest official Bedrock Edition server core on [the official Minecraft Bedrock website](https://www.minecraft.net/en-us/download/server/bedrock).
 
 ### Starting the Server
 


### PR DESCRIPTION
### 起因

在我的**国外机器**上按英文文档安装 MCSM 时，安装脚本卡在了 `Install Node.JS environment`

经过检查后发现机器无法连接国内的 `npmmirror` 镜像源，遂发现英文文档中有很多*中文的链接* / *国内镜像下载源*

### 修改内容

- Linux 一键安装脚本中的 `setup_cn` 改为 `setup`
- Windows ZIP 下载从国内镜像改为 GitHub Releases 下载
- Minecraft 基岩版下载链接的语言改为 `en-us`
- ~~*就这么多了，勿喷*~~