### PR TITLE
Fix OpenRC Documentation

### DIFF
--- a/advanced/linux_openrc.md
+++ b/advanced/linux_openrc.md
@@ -24,10 +24,11 @@ command="<NodeJS dir>/bin/node"
 command_args="app.js"
 supervise_daemon_args=" -d /opt/mcsmanager/daemon -e "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
 command_user="root"
+pidfile="/var/run/mcsmd.pid"
 
 reload() {
 	ebegin "Reloading $RC_SVCNAME"
-	/bin/kill -s HUP $MAINPID
+	${supervisor} ${RC_SVCNAME} --signal HUP --pidfile "${pidfile}"
 	eend $?
 }
 ```
@@ -44,10 +45,11 @@ command="<NodeJS dir>/bin/node"
 command_args="app.js"
 supervise_daemon_args=" -d /opt/mcsmanager/web -e "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
 command_user="root"
+pidfile="/var/run/mcsmw.pid"
 
 reload() {
 	ebegin "Reloading $RC_SVCNAME"
-	/bin/kill -s HUP $MAINPID
+	${supervisor} ${RC_SVCNAME} --signal HUP --pidfile "${pidfile}"
 	eend $?
 }
 ```

--- a/advanced/linux_openrc.md
+++ b/advanced/linux_openrc.md
@@ -25,12 +25,6 @@ command_args="app.js"
 supervise_daemon_args=" -d /opt/mcsmanager/daemon -e "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
 command_user="root"
 
-stop() {
-	ebegin "Stopping $RC_SVCNAME"
-	/bin/kill -s QUIT $MAINPID
-	eend $?
-}
-
 reload() {
 	ebegin "Reloading $RC_SVCNAME"
 	/bin/kill -s HUP $MAINPID
@@ -50,12 +44,6 @@ command="<NodeJS dir>/bin/node"
 command_args="app.js"
 supervise_daemon_args=" -d /opt/mcsmanager/web -e "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
 command_user="root"
-
-stop() {
-	ebegin "Stopping $RC_SVCNAME"
-	/bin/kill -s QUIT $MAINPID
-	eend $?
-}
 
 reload() {
 	ebegin "Reloading $RC_SVCNAME"

--- a/advanced/linux_openrc.md
+++ b/advanced/linux_openrc.md
@@ -25,6 +25,8 @@ command_args="app.js"
 supervise_daemon_args=" -d /opt/mcsmanager/daemon -e "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
 command_user="root"
 pidfile="/var/run/mcsmd.pid"
+output_log="/var/log/mcsm/daemon.log"
+error_log="/var/log/mcsm/daemon.err"
 
 reload() {
 	ebegin "Reloading $RC_SVCNAME"
@@ -46,6 +48,8 @@ command_args="app.js"
 supervise_daemon_args=" -d /opt/mcsmanager/web -e "PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"\""
 command_user="root"
 pidfile="/var/run/mcsmw.pid"
+output_log="/var/log/mcsm/web.log"
+error_log="/var/log/mcsm/web.err"
 
 reload() {
 	ebegin "Reloading $RC_SVCNAME"


### PR DESCRIPTION
This commit has two fixes, and an improvement.

Fix 1:
The `stop()` function can't be used with `supervisor-daemon`, since `supervisor-daemon` [requires the default start, stop, and status functions](https://github.com/OpenRC/openrc/blob/master/supervise-daemon-guide.md). 

If the `stop()` function is left as is, it will fail to actually stop either `mcsmd`, or `mcsmw` (or rather either node processes running the web UI and daemon) when `open-rc mcsmd/mcsmw stop` is run. Monitoring the system's running processes with `top`/`htop`/`btop`, or similar, when trying to stop either will show that they still run even after the stop command was issued.

Simply removing the `stop()` function fixes this issue. Using `open-rc mcsmd/mcsmw stop` will work just fine since `supervisor-daemon` uses the default stop function.

Fix 2:
The lines that use `/bin/kill -s $SOME_SIGNAL $MAINPID` fail to find a `PID` to send a signal to, since OpenRC does not use `$MAINPID` like systemd does and is left unset as a result. This was fixed by using [the `reload()` function example from the Gentoo wiki](https://wiki.gentoo.org/wiki/OpenRC/supervise-daemon#Instructions_per_service).

The improvement:
The location for log files were added. This is helpful since it puts them in the standard logging folder location; this will make them easier to find and in close proximity to logs for reverse proxies, or any other administrative tools needed to run MCSManager.